### PR TITLE
Use node 16 for action run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ inputs:
     required: false
     default: 'true'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Hey 👋 

the action popped up in our warnings:
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: irgaly/setup-mint@v1

As you already have set node to v17 in the `.node-version` file I'm pretty sure it is enough to just change the `using`?

Cheers.