### PR TITLE
Add mint-executable-directory option to mint installation directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
           mint-directory: example
       - shell: bash -xe {0}
         run: |
-          ls -alh "$HOME/bin" | grep mint
-          "$HOME/bin/mint" --version
-          "$HOME/bin/mint" list
+          ls -alh /usr/local/bin | grep mint
+          mint --version
+          mint list
           ls -alh ~/.mint
           ls -alh ~/.mint/packages/*/build/*
   test-linux:
@@ -29,8 +29,8 @@ jobs:
           mint-directory: example
       - shell: bash -xe {0}
         run: |
-          ls -alh "$HOME/bin" | grep mint
-          "$HOME/bin/mint" --version
-          "$HOME/bin/mint" list
+          ls -alh /usr/local/bin | grep mint
+          mint --version
+          mint list
           ls -alh ~/.mint
           ls -alh ~/.mint/packages/*/build/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           mint --version
           mint list
           ls -alh ~/.mint
+          ls -alh ~/.mint/bin
           ls -alh ~/.mint/packages/*/build/*
   test-linux:
     runs-on: ubuntu-latest
@@ -33,4 +34,5 @@ jobs:
           mint --version
           mint list
           ls -alh ~/.mint
+          ls -alh ~/.mint/bin
           ls -alh ~/.mint/packages/*/build/*

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ setup-mint step will do:
 
 * Retrieve mint version from Mintfile
   * Use mint@master if mint version is not specified in Mintfile
-* Install mint to $HOME/mint
+* Install mint to /usr/local/bin/mint
 * Cache mint binary for next run
 * Run `mint bootstrap` to install swift commands
 * Cleanup unused swift commands (not listed in Mintfile)
@@ -46,6 +46,8 @@ This action can be used in a macOS runner and a Linux runner.
       with:
         # a directory contains Mintfile, default: GITHUB_WORKSPACE
         mint-directory: .
+        # a directory where mint executable itself will be installed, default: /usr/local/bin
+        mint-executable-directory: /usr/local/bin
         # run mint bootstrap, default: true
         bootstrap: true
         # cache swift commands (~/.mint), default: true

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'a directory of Mintfile'
     required: false
     default: '.'
+  mint-executable-directory:
+    description: 'a directory where mint executable itself will be installed'
+    required: false
+    default: '/usr/local/bin'
   bootstrap:
     description: 'execute mint bootstrap'
     required: false


### PR DESCRIPTION
* relates
    * #23
    * #27
    * #24

---

* [x] Revert #24 changes, put mint to /usr/local/mint
* [x] Add mint-executable-directory for mint installation directory