### PR TITLE
1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-# v1.5.0 - 2024/07/06 JST
+# v1.6.0 - 2024/07/12 JST
+
+Revert v1.5.0's breaking change: $HOME/bin/mint -> /usr/local/bin/mint
+
+#### Fix
+
+* Add mint-executable-directory option to mint installation directory [#28](https://github.com/irgaly/setup-mint/pull/28)
+    * mint will be install to /usr/local/bin/mint
+    * add `mint-executable-directory` option
 
 #### Improve
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-mint-action",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-mint-action",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/cache": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-mint-action",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "dist/index.js",
   "private": true,
   "license": "Apache-2.0",


### PR DESCRIPTION
* #28
    * mint will be install to /usr/local/bin/mint
    * add `mint-executable-directory` option